### PR TITLE
Clarify instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This tool captures the audio from your desktop and streams it to a ChromeCast Audio device.
 
 You can download an installer from the [releases](https://github.com/SamDel/ChromeCast-Desktop-Audio-Streamer/releases).
+After running setup.exe you can run the installed program from `C:\Program Files (x86)\Desktop Audio Streamer\Desktop Audio Streamer\ChromeCast.Desktop.AudioStreamer.exe`.
+On the first run Windows will ask you to configure the firewall and this must be enabled for your home-network type (public or private) for audio to play.
 
 Please read the [wiki](https://github.com/SamDel/ChromeCast-Desktop-Audio-Streamer/wiki) page for further information, and the [developers](https://github.com/SamDel/ChromeCast-Desktop-Audio-Streamer/wiki/Developers) page to get it to work in Visual Studio.
 


### PR DESCRIPTION
The README explains where to find installers but not where to find the
installed executable. This can lead to initial confusion. This change
explains where to find the executable, and also points out the importance
of configuring the firewall correctly.